### PR TITLE
Removing bootstrap navigation

### DIFF
--- a/src/components/header.js
+++ b/src/components/header.js
@@ -1,45 +1,61 @@
-import PropTypes from "prop-types"
-import React from "react"
-import { Link } from "gatsby"
+import React, { Component } from 'react'
+import { Link } from 'gatsby';
 import Logo from "../images/Online-Property-Logo.png"
 
-const Header = ({ siteTitle }) => (
-
-  <header role="banner">
-    <nav className="navbar navbar-default navbar-fixed-top shadow-sm">
-      <div className="container-fluid">
-        <div className="navbar-header">
-          <button type="button" className="navbar-toggle collapsed" data-toggle="collapse" data-target="#main-nav" aria-expanded="false">
-            <span className="sr-only">Toggle navigation</span>
-            <span className="icon-bar"></span>
-            <span className="icon-bar"></span>
-            <span className="icon-bar"></span>
-          </button>
-          <Link className="navbar-brand" to="/"><img alt="Online Property Auctions Scotland Ltd" src={Logo} /></Link>
-        </div>
-
-        <div className="collapse navbar-collapse" id="main-nav">
-          <ul className="nav navbar-nav">
-            <li><Link to="/">Home</Link></li>
-            <li><a href="/auction/">Auction</a></li>
-            <li><Link to="/sell/">Sell</Link></li>
-            <li><Link to="/about-us/">About us</Link></li>
-            <li><Link to="/contact/">Contact</Link></li>
-          </ul>
-          <a href="/auction/#!/login" className="btn btn-secondary navbar-btn ml-1 x-bidlogix--trigger-login">Sign Up/Log in</a>
-          <p className='hidden-sm navbar-text pull-right'>Phone: <a href="tel:+441412660125">0141 266 0125</a></p>
-        </div>
-      </div>
-    </nav>
-  </header>
-)
-
-Header.propTypes = {
-  siteTitle: PropTypes.string,
+const Header = () => {
+  return (
+    <React.Fragment>
+      <RenderBody />
+    </React.Fragment>
+  )
 }
 
-Header.defaultProps = {
-  siteTitle: ``,
+class RenderBody extends Component {
+  constructor() {
+    super()
+    this.state = {
+      expanded: false
+    }
+    this.toggleNav = this.toggleNav.bind(this);
+  }
+  toggleNav() {
+    this.setState({
+      expanded:!this.state.expanded
+    })
+  }
+  render() {
+    return (
+      <React.Fragment>
+        <header role="banner">
+          <nav className="navbar navbar-default navbar-fixed-top shadow-sm">
+            <div className="container-fluid">
+              <div className="navbar-header">
+                <button className="navbar-toggle" aria-expanded={this.state.expanded} type='button' onClick={ this.toggleNav } onKeyDown={ this.toggleNav }>
+                  <span className="sr-only">Toggle navigation</span>
+                  <span className="icon-bar"></span>
+                  <span className="icon-bar"></span>
+                  <span className="icon-bar"></span>
+                </button>
+                <Link className="navbar-brand" to="/"><img alt="Online Property Auctions Scotland Ltd" src={Logo} /></Link>
+              </div>
+
+              <div hidden={!this.state.expanded} id="main-nav">
+                <ul className="nav navbar-nav">
+                  <li><Link to="/" activeClassName="active" >Home</Link></li>
+                  <li><a href="/auction/">Auction</a></li>
+                  <li><Link to="/sell/" activeClassName="active">Sell</Link></li>
+                  <li><Link to="/about-us/" activeClassName="active">About us</Link></li>
+                  <li><Link to="/contact/" activeClassName="active">Contact</Link></li>
+                </ul>
+                <a href="/auction/#!/login" className="btn btn-secondary navbar-btn x-bidlogix--trigger-login">Sign Up/Log in</a>
+                <p className='hidden-sm navbar-text navbar-right'>Phone: <a href="tel:+441412660125">0141 266 0125</a></p>
+              </div>
+            </div>
+          </nav>
+        </header>
+      </React.Fragment>
+    )
+  }
 }
 
 export default Header

--- a/src/styles/custom-mapping.scss
+++ b/src/styles/custom-mapping.scss
@@ -80,6 +80,15 @@ body {
   }
 }
 
+.navbar-btn {
+  @extend .ml-1;
+}
+@media (max-width: $grid-float-breakpoint) {
+  a.navbar-btn {
+    margin:0 !important;
+  }
+}
+
 .panel.panel-primary {
   background-color: $panel-primary-border; 
   color: $color-off-white;
@@ -94,6 +103,12 @@ body {
 }
 
 @media (min-width: $grid-float-breakpoint) {
+  .navbar div[hidden] {
+    display:block !important;
+  }
+  p.navbar-right {
+    margin-right: 0;
+  }
   .navbar-default .navbar-nav {
     > li {
       > a {
@@ -103,15 +118,6 @@ body {
     }
   }
 }
-
-a {
-  display:inline-block;
-  &:hover,
-  &:focus {
-    text-underline-position: under;
-  }
-}
-
 
 /* BidLogix Specific */
 .bidlogix-app .grid-item {


### PR DESCRIPTION
I noticed a bug where you can open the navigation on a mobile, but you can't close it again. You can view this on your mobile on the live site.

This is because Bootstrap tries to manipulate the DOM, but react tries to hold it firm using Shadow DOM.

Long story short, bootstrap collapse doesn't work with react. and i don't want to bring in a library like react-bootstrap or react-strap.

So instead ive re-written the header component and used good old plain css to show and hide the navigation. and forced it to BLOCK when on desktop.